### PR TITLE
Manually unescapes \( and \) in URIs to address issue #9

### DIFF
--- a/newpax.dtx
+++ b/newpax.dtx
@@ -1019,6 +1019,8 @@ local function outputKV_uri (pdfedict)
   if hex then
     a = a .. strHEX_STR_BEG .. value .. strHEX_STR_END
   else
+    value = string.gsub(value, [[%\%(]], "(")
+    value = string.gsub(value, [[%\%)]], ")")
     a = a .. strLIT_STR_BEG ..value .. strLIT_STR_END
   end
     a = a .. strVALUE_END .. strKV_END


### PR DESCRIPTION
Unfortunately using `\tl_to_str:V` does not seem to be enough to remove the backspace in front of parentheses in URIs. I applied the fix from 4746c9a4ed37ac7537d8f87af4ee6ced11667a66 manually to the file `/usr/share/texmf-dist/tex/latex/newpax/newpax.sty` on my system but the issue still persisted for my use case (a DOI reference).

I therefore changed the `newpax.lua` file using `string.gsub` to substitute escaped parentheses with unescaped ones. This is a little hacky, since it only addresses parentheses and no other characters, but it works. I would be happy to extend this to a more general fix, but I currently lack the knowledge of how URLs are encoded in PDF and how `\tl_to_str:V` is actually supposed to work.

Like in #11 , I only tested this locally for my own use case and not by actually re-building and installing the package from source.