### PR TITLE
Sort destinations to ensure constant order and prevent endless compilation

### DIFF
--- a/newpax.dtx
+++ b/newpax.dtx
@@ -1480,9 +1480,17 @@ local function __writepax (ext,file)
   for i=1,#collected_destinations do
    WRITE (collected_destinations[i])
   end
+  -- order must be constant
+  local destnames = {}
+  for destname, destval in pairs(destnamestorefVAR) do
+    table.insert(destnames, destname)
+  end
+  table.sort(destnames)
   -- write out the rest of the destinations.
-  for k,v in pairs (destnamestorefVAR) do
-   -- ignore use dests and page destinations. 
+  for i_dest = 1, #destnames do
+    k=destnames[i_dest]
+    v=destnamestorefVAR[k]
+   -- ignore use dests and page destinations.
     i=string.find(k,"page.",1) 
     if not useddestnames[k] and not i then
       destcountVAR=destcountVAR + 1


### PR DESCRIPTION
Tables lua are not sorted, and the order they are printed in is thus not constant. This means that, using the current implementation, the newpax file (and thus also the corresponding aux) change on every compilation round – resulting in a never-ending compilation loop. By simply first sorting the destinations, the order is ensured to stay constant, thereby resolving this issue.

I am aware that tests would be beneficial for this, unfortunately I have not had the opportunity to figure out how to write those for a TeX package.